### PR TITLE
Fix variable typo that caused improperly sized elements.

### DIFF
--- a/mercury-drop.html
+++ b/mercury-drop.html
@@ -182,7 +182,7 @@ Polymer({
 
       box = document.createElement('div');
       box.style.height = this.elHeight + 'px';
-      box.style.width = this.elWidht + 'px';
+      box.style.width = this.elWidth + 'px';
       box.className = 'phantom-box';
 
       return box;


### PR DESCRIPTION
Just a typo that caused the width of elements to be wrong.
